### PR TITLE
Date clarity

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,7 @@
 ## Participating in Norfolk, VA? [Click Here](https://github.com/norfolkjs/nodebotsday/wiki)
 ---
 ---
-## NodeBots Day 7/27
+## NodeBots Day 7/26, 7/27
 
 NodeBots Day is back for 2014. We'll join together across the world to create and learn.
 


### PR DESCRIPTION
Any organizers that don't explicitly list the date of their even here should do so. Some of these are on the 26th and some are on the 27th so it could be confusing for attendees.
