### PR TITLE
Add Los Angeles

### DIFF
--- a/2016/la/README.md
+++ b/2016/la/README.md
@@ -1,0 +1,29 @@
+# NodeBots Day 2016 for Los Angeles!
+
+ - Organizers: Creative Artists Agency (CAA) caanodebotevent@caa.com
+ - Home Page: http://nodebots.nyc/
+ - Ticket Link: N/A - free
+ - Location: 2000 Avenue of the Stars, Los Angeles, CA 90067
+ - Date: {TBD} June 30th or August 6th
+ - Hours: 8am-5pm
+ - Expected # of attendees: 80 (maybe more later)
+ - Sponsors:
+  * [CAA](https://caa.com)
+
+# TODO
+
+ - [ ] Recruit Sponsors
+ - [x] Figure out how you're feeding your attendees if you're feeding them
+ - [x] Secure a location
+ - [x] Determine a Time
+ - [x] Determine a Max # of attendees:
+ - [ ] Recruit Volunteers (1 for every 10 works if you've done this before)
+ - [ ] Determine Curriculum and Projects
+ - [x] Setup Ticketing Presales (N/A - free)
+ - [ ] Order Parts
+ - [ ] Recruit Attendees (See #193)
+
+# Notes
+We're working on our curriculum.  We're still looking for Volunteers.  The event will be attended by High School Students from Communities and Schools.
+
+We're likely using Tessel 2

--- a/Readme.md
+++ b/Readme.md
@@ -42,6 +42,7 @@ Want to organize a local NodeBots Day event. You should!
  - [Boston, Massachusetts, USA](2016/boston/)
  - [Dayton, OH, USA](2016/dayton/)
  - [Houston, Texas, USA](2016/houston/)
+ - [Los Angeles, California, USA](2016/la)
  - [New York City, USA](2016/nyc/)
  - [Norfolk, Virginia, USA](2016/norfolk)
 


### PR DESCRIPTION
CAA will be hosting a nodebots event as part of our CAA Foundation, working with High School kids from a relationship we have with Communities and Schools.  We hope to have volunteers from js.la 